### PR TITLE
build.sh: add new CFLAGS for smaller size

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,7 +59,7 @@ pmufw_build()
     AR=${CROSS}ar
     AS=${CROSS}as
     OBJCOPY=${CROSS}objcopy
-    CFLAGS="-mlittle-endian -mxl-barrel-shift -mxl-pattern-compare -mno-xl-reorder -mcpu=v9.2 -mxl-soft-mul -mxl-soft-div"
+    CFLAGS="-mlittle-endian -mxl-barrel-shift -mxl-pattern-compare -mno-xl-reorder -mcpu=v9.2 -mxl-soft-mul -mxl-soft-div -Os -flto -ffat-lto-objects"
 
     ../misc/copy_bsp.sh
 


### PR DESCRIPTION
Later versions of PMUFW have started to grow in size, and one may
encounter a compilation error regarding overflowing the PMU_RAM region.

Xilinx recommends adding the -Os, -flto, and -ffat-lto-objects flags.

See:
https://forums.xilinx.com/t5/Embedded-Processor-System-Design/2017-3-PMUFW-compilation-failure-on-zynqmp-UltraScale-RAM/td-p/802155

Signed-off-by: Joel Carlson <JoelsonCarl@gmail.com>