### PR TITLE
Update PMUFW with embeddedsw 2018.2

### DIFF
--- a/0001-Load-XPm_ConfigObject-at-boot.patch
+++ b/0001-Load-XPm_ConfigObject-at-boot.patch
@@ -1,37 +1,37 @@
-From 3a1f60c4dd7d68f5243629890a57a37a34e45671 Mon Sep 17 00:00:00 2001
+From cda493b023da779f9a6fe0abd938b0f2480175d1 Mon Sep 17 00:00:00 2001
 From: Mike Looijmans <mike.looijmans@topic.nl>
 Date: Tue, 3 Oct 2017 10:09:07 +0200
-Subject: [PATCH 1/2] Load XPm_ConfigObject at boot
+Subject: [PATCH] Load XPm_ConfigObject at boot
 
 This appears to be something that the FSBL does, but not the SPL loader, so
 do it here.
 ---
- lib/sw_apps/zynqmp_pmufw/src/pm_binding.c | 6 ++++++
- 1 file changed, 6 insertions(+)
+ lib/sw_apps/zynqmp_pmufw/src/pm_binding.c | 5 +++++
+ 1 file changed, 5 insertions(+)
 
 diff --git a/lib/sw_apps/zynqmp_pmufw/src/pm_binding.c b/lib/sw_apps/zynqmp_pmufw/src/pm_binding.c
-index c0144b1..efaf18d 100644
+index cb617e5cb..1dc1ea4d7 100644
 --- a/lib/sw_apps/zynqmp_pmufw/src/pm_binding.c
 +++ b/lib/sw_apps/zynqmp_pmufw/src/pm_binding.c
-@@ -46,6 +46,9 @@
- #include "pm_gic_proxy.h"
- #include "pm_requirement.h"
+@@ -48,6 +48,10 @@
  #include "pm_extern.h"
+ #include "pm_usb.h"
+ #include "pm_hooks.h"
 +#include "pm_config.h"
 +
 +extern u32 XPm_ConfigObject[]; /* pm_cfg_obj.c */
++
  
  /* All GIC wakes in GPI1 */
  #define PMU_IOMODULE_GPI1_GIC_WAKES_ALL_MASK \
-@@ -70,6 +73,8 @@ void XPfw_PmInit(void)
- 	PmMasterDefaultConfig();
- 
- 	PmNodeConstruct();
-+	
-+	PmConfigLoadObject((u32)&XPm_ConfigObject, 0xFFFFFFFFU);
+@@ -87,6 +91,7 @@ void XPfw_PmInit(void)
+ 	if (bootType == PM_COLD_BOOT) {
+ 		PmMasterDefaultConfig();
+ 		PmNodeConstruct();
++		PmConfigLoadObject((u32)&XPm_ConfigObject, 0xFFFFFFFFU);
+ 	}
  }
  
- /**
 -- 
-1.9.1
+2.11.0
 


### PR DESCRIPTION
Bump to embeddedsw version xilinx-v2018.2.

This version should include a newer PMU firmware. The PMU Xilinx support in Linux kernel xilinx-v2018.2 requires PMU version 1.0 instead of 0.3 otherwise it won't boot.

This patch upsteps embeddedsw to  xilinx-v2018.2 and updates the patch to apply cleanly.