### PR TITLE
Use https proto for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "crosstool-ng"]
 	path = crosstool-ng
-	url = git://github.com/crosstool-ng/crosstool-ng.git
+	url = https://github.com/crosstool-ng/crosstool-ng.git
 [submodule "embeddedsw"]
 	path = embeddedsw
-	url = git://github.com/Xilinx/embeddedsw.git
+	url = https://github.com/Xilinx/embeddedsw.git

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Usage
 
 1. Get the source code:
 
-       git clone --recursive https://github.com/lucaceresoli/zynqmp-pmufw-builder.git
+       git clone --recurse-submodules https://github.com/lucaceresoli/zynqmp-pmufw-builder.git
        cd zynqmp-pmufw-builder
 
 2. Generate a suitable microblaze toolchain (this is normally needed


### PR DESCRIPTION
Get this error otherwise
```
...
Submodule 'crosstool-ng' (git://github.com/crosstool-ng/crosstool-ng.git) registered for path 'crosstool-ng'
Submodule 'embeddedsw' (git://github.com/Xilinx/embeddedsw.git) registered for path 'embeddedsw'
Cloning into '/tmp/zynqmp-pmufw-builder/crosstool-ng'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
...
```
