### PR TITLE
Suppress gcc 11 warnings about memcpy operations to raw memory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -64,7 +64,7 @@ pmufw_build()
     AR=${CROSS}ar
     AS=${CROSS}as
     OBJCOPY=${CROSS}objcopy
-    CFLAGS="-mlittle-endian -mxl-barrel-shift -mxl-pattern-compare -mno-xl-reorder -mcpu=v9.2 -mxl-soft-mul -mxl-soft-div -Os -flto -ffat-lto-objects"
+    CFLAGS="-Wno-stringop-overflow -mlittle-endian -mxl-barrel-shift -mxl-pattern-compare -mno-xl-reorder -mcpu=v9.2 -mxl-soft-mul -mxl-soft-div -Os -flto -ffat-lto-objects"
 
     ../misc/copy_bsp.sh
 


### PR DESCRIPTION
There are two places where this new warning is showing up, both occurrences are in the same file xpfw_restart.c

```
In function 'XPfw_StoreFsblToDDR',
    inlined from 'XPfw_StoreFsblToDDR' at xpfw_restart.c:636:5:
xpfw_restart.c:656:31: warning: 'memcpy' writing 174080 bytes into a region of size 0 overflows the destination [-Wstringop-overflow=]
  656 |                         (void)memcpy((u32 *)FSBL_STORE_ADDR, (u32 *)FSBL_LOAD_ADDR,
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  657 |                                         FSBL_IMAGE_SIZE);
      |                                         ~~~~~~~~~~~~~~~~
In function 'XPfw_RestoreFsblToOCM',
    inlined from 'XPfw_RestoreFsblToOCM' at xpfw_restart.c:693:5:
xpfw_restart.c:718:23: warning: 'memcpy' writing 174080 bytes into a region of size 0 overflows the destination [-Wstringop-overflow=]
  718 |                 (void)memcpy((u32 *)FSBL_LOAD_ADDR, (u32 *)FSBL_STORE_ADDR,
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  719 |                                 FSBL_IMAGE_SIZE);
      |                                 ~~
```~~~~~~~~~~~~~~

The warning shows up in both the compile and link stages, so you end up getting 4 warnings total.