### PR TITLE
build.sh: pmufw_build(): allow custom CFLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Usage
        ./build.sh pmufw-build
 
    The PMU firmware will be called `pmufw.bin` in the current directory.
+   Custom compiler clags can be passed in the `CFLAGS` environment
+   variable, E.G.:
+
+       CFLAGS="-DENABLE_EM" ./build.sh pmufw-build
 
 Enjoy!
 

--- a/build.sh
+++ b/build.sh
@@ -64,7 +64,7 @@ pmufw_build()
     AR=${CROSS}ar
     AS=${CROSS}as
     OBJCOPY=${CROSS}objcopy
-    CFLAGS="-Wno-stringop-overflow -mlittle-endian -mxl-barrel-shift -mxl-pattern-compare -mno-xl-reorder -mcpu=v9.2 -mxl-soft-mul -mxl-soft-div -Os -flto -ffat-lto-objects"
+    CFLAGS+=" -Wno-stringop-overflow -mlittle-endian -mxl-barrel-shift -mxl-pattern-compare -mno-xl-reorder -mcpu=v9.2 -mxl-soft-mul -mxl-soft-div -Os -flto -ffat-lto-objects"
 
     ../misc/copy_bsp.sh
 


### PR DESCRIPTION
For some use cases it is interesting to be able to specify extra custom
compiler flags, so simply append to the CFLAGS specified in the environment
rather than completely overriding it - E.G.  to enable the "error
management" module so the watchdogs work:

CFLAGS="-DENABLE_EM" ./build.sh pmufw-build

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>