### PR TITLE
build.sh: use dry-run to verify if patch already applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Usage
        ./build.sh toolchain
 
    At the end a toolchain will be available in
-   `~/x-tools/microblazeel-unknown-elf/`.
+   `~/x-tools/microblazeel-xilinx-elf/`.
 
 3. Build it:
 

--- a/build.sh
+++ b/build.sh
@@ -47,8 +47,12 @@ pmufw_build()
     TOPDIR="$(pwd)"
 
     FIX_PATCH="pmufw-misc-Makefile-specify-sequential-Makefiles.patch"
-    patch --force -p1 --directory=embeddedsw <${FIX_PATCH} || \
-	echo "NOTE: ${FIX_PATCH} probably already applied, skipping it"
+    if ! patch -R -p1 -s -f --dry-run --silent --directory=embeddedsw <${FIX_PATCH} 1>/dev/null
+    then
+	patch --force -p1 --directory=embeddedsw <${FIX_PATCH}
+    else
+	echo "patch ${FIX_PATCH} already applied, skipping it"
+    fi
 
     cd embeddedsw/lib/sw_apps/zynqmp_pmufw/src/
 


### PR DESCRIPTION
The build.sh script applies the pmufw-misc-Makefile-specify-sequential-Makefiles.patch every time "./build.sh pmufw-build" is executed.  The problem with this is that it corrupts the embeddedsw directory when the patch has already been applied, so future builds could fail if executing "./build.sh pmufw-build" multiple times.

The patch includes with this pull request resolves the issue by attempting to dry-run a reverse patch to see if the patch has already been applied.  This way, the patch will only be applied on the first execution of "./build.sh pmufw-build" and the embeddedsw directory does not get corrupted on subsequent builds.