### PR TITLE
build.sh: merge k24 and k26 configs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,7 @@ pmufw_build()
     CFLAGS+=" -Wno-stringop-overflow -mlittle-endian -mxl-barrel-shift -mxl-pattern-compare -mno-xl-reorder -mcpu=v9.2 -mxl-soft-mul -mxl-soft-div -Os -flto -ffat-lto-objects"
 
     case ${BOARD_CONFIG} in
-	kria) CFLAGS+=" -DBOARD_SHUTDOWN_PIN=2 -DBOARD_SHUTDOWN_PIN_STATE=0 -DENABLE_EM -DENABLE_MOD_OVERTEMP -DENABLE_DYNAMIC_MIO_CONFIG -DENABLE_IOCTL -DCONNECT_PMU_GPO_2_VAL=0" ;;
+	kria|k26|k24) CFLAGS+=" -DBOARD_SHUTDOWN_PIN=2 -DBOARD_SHUTDOWN_PIN_STATE=0 -DENABLE_EM -DENABLE_MOD_OVERTEMP -DENABLE_DYNAMIC_MIO_CONFIG -DENABLE_IOCTL -DCONNECT_PMU_GPO_2_VAL=0" ;;
 	"") ;;
 	*)  usage_exit 1 "Unknown config '${BOARD_CONFIG}'" ;;
     esac

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ usage()
     echo
     echo "    CONFIG is an optional configuration preset for a specific SoM or board."
     echo "    Available configs:"
-    echo "        - k26           Xilinx Kria K26 SoM"
+    echo "        - kria           Xilinx Kria K26/K24 SoMs"
 }
 
 # $1: exit value
@@ -63,7 +63,7 @@ pmufw_build()
     CFLAGS+=" -Wno-stringop-overflow -mlittle-endian -mxl-barrel-shift -mxl-pattern-compare -mno-xl-reorder -mcpu=v9.2 -mxl-soft-mul -mxl-soft-div -Os -flto -ffat-lto-objects"
 
     case ${BOARD_CONFIG} in
-	k26) CFLAGS+=" -DBOARD_SHUTDOWN_PIN=2 -DBOARD_SHUTDOWN_PIN_STATE=0 -DENABLE_EM -DENABLE_MOD_OVERTEMP -DENABLE_DYNAMIC_MIO_CONFIG -DENABLE_IOCTL -DCONNECT_PMU_GPO_2_VAL=0" ;;
+	kria) CFLAGS+=" -DBOARD_SHUTDOWN_PIN=2 -DBOARD_SHUTDOWN_PIN_STATE=0 -DENABLE_EM -DENABLE_MOD_OVERTEMP -DENABLE_DYNAMIC_MIO_CONFIG -DENABLE_IOCTL -DCONNECT_PMU_GPO_2_VAL=0" ;;
 	"") ;;
 	*)  usage_exit 1 "Unknown config '${BOARD_CONFIG}'" ;;
     esac


### PR DESCRIPTION
AMD is about to release a new K24 SOM along with a KD240 Starter Kit.  It will be a lower end SOM with less memory and a smaller zynqmp to support applications that do not require the features of a K26 SOM.

Since both the K24 and K26 SOMs use the same pmufw defines, this patch combines support for both SOMs by switching to a combined build option called "kria".