### PR TITLE
build.sh: new kria config option

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,9 @@ usage()
     echo
     echo "    CONFIG is an optional configuration preset for a specific SoM or board."
     echo "    Available configs:"
-    echo "        - k26           Xilinx Kria K26 SoM"
+    echo "        - kria          AMD/Xilinx Kria SoM"
+    echo "        - k26           Deprecated config option since all Kria SoMs"
+    echo "                        will have the same additional build config."
 }
 
 # $1: exit value
@@ -63,7 +65,7 @@ pmufw_build()
     CFLAGS+=" -Wno-stringop-overflow -mlittle-endian -mxl-barrel-shift -mxl-pattern-compare -mno-xl-reorder -mcpu=v9.2 -mxl-soft-mul -mxl-soft-div -Os -flto -ffat-lto-objects"
 
     case ${BOARD_CONFIG} in
-	k26) CFLAGS+=" -DBOARD_SHUTDOWN_PIN=2 -DBOARD_SHUTDOWN_PIN_STATE=0 -DENABLE_EM -DENABLE_MOD_OVERTEMP -DENABLE_DYNAMIC_MIO_CONFIG -DENABLE_IOCTL -DCONNECT_PMU_GPO_2_VAL=0" ;;
+	kria|k26) CFLAGS+=" -DBOARD_SHUTDOWN_PIN=2 -DBOARD_SHUTDOWN_PIN_STATE=0 -DENABLE_EM -DENABLE_MOD_OVERTEMP -DENABLE_DYNAMIC_MIO_CONFIG -DENABLE_IOCTL -DCONNECT_PMU_GPO_2_VAL=0" ;;
 	"") ;;
 	*)  usage_exit 1 "Unknown config '${BOARD_CONFIG}'" ;;
     esac

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ set -u
 
 usage()
 {
-    echo "Usage: $(basename $0) [-c CONFIG] SUBCMD"
+    echo "Usage: $(basename "$0") [-c CONFIG] SUBCMD"
     echo
     echo "    SUBCMD can be:"
     echo "        - toolchain     install crosstool-NG locally and build toolchain"
@@ -29,7 +29,7 @@ usage_exit()
 	echo "${2:-}"
 	usage
     ) >&2
-    exit ${1}
+    exit "${1}"
 }
 
 build_toolchain()


### PR DESCRIPTION
AMD is about to release a new K24 SOM along with a KD240 Starter Kit.  It will be a lower end SOM with less memory and a smaller zynqmp to support applications that do not require the features of a K26 SOM.

Since both the K24 and K26 SOMs use the same pmufw defines, this patch combines support for both SOMs by switching to a combined build option called "kria".

The previous build option "k26" is now deprecated and only kept for backwards compatibility reasons.