### PR TITLE
embeddedsw: bump to xilinx_v2024.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -57,7 +57,7 @@ pmufw_build()
     CFLAGS+=" -Wno-stringop-overflow -mlittle-endian -mxl-barrel-shift -mxl-pattern-compare -mno-xl-reorder -mcpu=v9.2 -mxl-soft-mul -mxl-soft-div -Os -flto -ffat-lto-objects"
 
     case ${BOARD_CONFIG} in
-	kria|k26) CFLAGS+=" -DBOARD_SHUTDOWN_PIN=2 -DBOARD_SHUTDOWN_PIN_STATE=0 -DENABLE_EM -DENABLE_MOD_OVERTEMP -DENABLE_DYNAMIC_MIO_CONFIG -DENABLE_IOCTL -DCONNECT_PMU_GPO_2_VAL=0" ;;
+	kria|k26) CFLAGS+=" -DK26_SOM" ;;
 	"") ;;
 	*)  usage_exit 1 "Unknown config '${BOARD_CONFIG}'" ;;
     esac


### PR DESCRIPTION
This patch bumps the embeddedsw repo to the xilinx_v2024.1 release.

Included in the xilinx_v2024.1 release are new defines K26_SOM and K24_SOM for building the zynqmp-pmufw for Kria SOMs.  The build.sh script has been updated to use the new K26_SOM define.

Details of the new define can be found in the following commits: 
https://github.com/Xilinx/embeddedsw/commit/b1fc62f7475c93f648468df1e40254f9f41f1995
https://github.com/Xilinx/embeddedsw/commit/b4c76e7776ceaaaf2b8f7d60b9d631bef64a451f