### PR TITLE
build.sh: remove CC_FLAGS from CFLAGS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,7 +54,7 @@ pmufw_build()
     CC=${CROSS}gcc
     AR=${CROSS}ar
     OBJCOPY=${CROSS}objcopy
-    CFLAGS+=" -Wno-stringop-overflow -mlittle-endian -mxl-barrel-shift -mxl-pattern-compare -mno-xl-reorder -mcpu=v9.2 -mxl-soft-mul -mxl-soft-div -Os -flto -ffat-lto-objects"
+    CFLAGS+=" -Os -flto -ffat-lto-objects"
 
     case ${BOARD_CONFIG} in
 	kria|k26) CFLAGS+=" -DK26_SOM" ;;


### PR DESCRIPTION
This patch removes the build flags which are defined as the CC_FLAGS in the zynqmp_pmufw Makefile.  There is no reason to define them as CFLAGS since they are already covered by the CC_FLAGS parameter which the build.sh script is not overwriting.

The CC_FLAGS and CFLAGS default definitions can be found in the src/Makefile: https://github.com/Xilinx/embeddedsw/blob/master/lib/sw_apps/zynqmp_pmufw/src/Makefile

CC_FLAGS := -MMD -MP    -mlittle-endian -mxl-barrel-shift -mxl-pattern-compare -mcpu=v9.2 -mxl-soft-mul
CFLAGS := -Os -flto -ffat-lto-objects